### PR TITLE
Fix accordion layout

### DIFF
--- a/client/src/pages/Reference.css
+++ b/client/src/pages/Reference.css
@@ -81,3 +81,14 @@ body.dark .accordion-header:hover {
 body.dark .accordion-content {
   background-color: #2a2a2a;
 }
+
+.reference-page {
+  max-width: 1000px;
+}
+
+.accordion-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  align-items: start;
+}

--- a/client/src/pages/Reference.jsx
+++ b/client/src/pages/Reference.jsx
@@ -20,7 +20,7 @@ export default function Reference() {
   };
 
   return (
-    <div className="container">
+    <div className="container reference-page">
       <h2>Reference Guide</h2>
       <input
         type="text"
@@ -30,26 +30,28 @@ export default function Reference() {
         className="search-bar"
       />
 
-      {Object.entries(grouped).map(([category, items]) => (
-        <div key={category} className="accordion-section">
-          <div className="accordion-header" onClick={() => toggleCategory(category)}>
-            <h3>{category}</h3>
-            <span className="chevron">{openCategory === category ? '▲' : '▼'}</span>
+      <div className="accordion-grid">
+        {Object.entries(grouped).map(([category, items]) => (
+          <div key={category} className="accordion-section">
+            <div className="accordion-header" onClick={() => toggleCategory(category)}>
+              <h3>{category}</h3>
+              <span className="chevron">{openCategory === category ? '▲' : '▼'}</span>
+            </div>
+            <div
+              className="accordion-content"
+              style={{ display: openCategory === category ? 'block' : 'none' }}
+            >
+              <ul className="reference-list">
+                {items.map((item, idx) => (
+                  <li key={idx}>
+                    <strong>{item.term}</strong>: {item.definition}
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
-          <div
-            className="accordion-content"
-            style={{ display: openCategory === category ? 'block' : 'none' }}
-          >
-            <ul className="reference-list">
-              {items.map((item, idx) => (
-                <li key={idx}>
-                  <strong>{item.term}</strong>: {item.definition}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ensure accordion sections don't stretch when a neighboring item expands

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842087d23d08325a564aae8c468f987