### PR TITLE
Add machine quiz CSS styles

### DIFF
--- a/client/src/components/machine.css
+++ b/client/src/components/machine.css
@@ -56,3 +56,46 @@
   margin-bottom: 10px;
 }
 
+/* Quiz Mode Info */
+.machine-quiz-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #eee;
+  color: #000;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+}
+
+body.dark .machine-quiz-info {
+  background-color: #003838;
+  color: #f0f0f0;
+  border-color: #004d4d;
+}
+
+.machine-quiz-part {
+  font-weight: bold;
+  color: #DE9250;
+}
+body.dark .machine-quiz-part {
+  color: #ffb162;
+}
+
+.machine-quiz-feedback {
+  font-weight: 600;
+  margin-top: 0.5rem;
+}
+.machine-quiz-feedback.correct {
+  color: #2E8B57; /* green tone */
+}
+.machine-quiz-feedback.incorrect {
+  color: #A35752; /* red tone */
+}
+
+.machine-btn {
+  margin: 0.5rem;
+}
+


### PR DESCRIPTION
## Summary
- style machine quiz info section
- provide dark-mode adjustments
- style quiz part text and feedback colors
- add small spacing on machine quiz buttons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68688ff687188325a7ae21d87f152aa8