### PR TITLE
Add quiz feedback reset effect

### DIFF
--- a/client/src/components/Machine.jsx
+++ b/client/src/components/Machine.jsx
@@ -137,6 +137,14 @@ const Machine = () => {
     return () => window.removeEventListener("resize", updateSize);
   }, []);
 
+  // Reset feedback when a new quiz part is chosen
+  useEffect(() => {
+    if (quizPart) {
+      const timeout = setTimeout(() => setQuizFeedback(""), 1000);
+      return () => clearTimeout(timeout);
+    }
+  }, [quizPart]);
+
   // Update size when image loads
   function handleImageLoad() {
     if (imgRef.current) {


### PR DESCRIPTION
## Summary
- reset quiz feedback when quiz part changes
- allow short delay so "Correct!" briefly shows before clearing

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `client`

------
https://chatgpt.com/codex/tasks/task_e_6869a35babd083258285e25def78277b