### PR TITLE
Remove unused swipeable packages

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,9 +10,7 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.4.1",
-        "react-swipeable": "^7.0.2",
-        "swipeable": "^1.0.5"
+        "react-router-dom": "^7.4.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -2503,15 +2501,6 @@
         "react-dom": ">=18"
       }
     },
-    "node_modules/react-swipeable": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
-      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2643,23 +2632,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/swipeable": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/swipeable/-/swipeable-1.0.5.tgz",
-      "integrity": "sha512-dM+guhHbjahkwyV7wgMvnhNSKcEd4fHPgi0nPL2lLGqnyqldZNSPUehoVphzC/sKqQoaliri5WYepP+dqROHcw==",
-      "license": "MIT"
-    },
     "node_modules/turbo-stream": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
       "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
       "license": "ISC"
-    },
-    "node_modules/type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"

--- a/client/package.json
+++ b/client/package.json
@@ -12,9 +12,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.4.1",
-    "react-swipeable": "^7.0.2",
-    "swipeable": "^1.0.5"
+    "react-router-dom": "^7.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",


### PR DESCRIPTION
## Summary
- clean up client `package.json` by removing `react-swipeable` and `swipeable`
- remove the same dependencies from `package-lock.json`

## Testing
- `npm test` in `client`

------
https://chatgpt.com/codex/tasks/task_e_6869a361ad1483258bf9d07fc6542154