### PR TITLE
Reduce hotspot size on small screens

### DIFF
--- a/client/src/components/machine.css
+++ b/client/src/components/machine.css
@@ -105,8 +105,9 @@ body.dark .machine-quiz-part {
   }
 
   .hotspot-button {
-    width: 10px;
-    height: 10px;
+    /* Slightly smaller hotspots to reduce overlap on small screens */
+    width: 6px;
+    height: 6px;
   }
 
   .machine-btn {


### PR DESCRIPTION
## Summary
- tweak `.hotspot-button` size in the small‐screen media query so hotspots don't overlap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869a819fa788325b51978e048fda43d