### PR TITLE
Update quiz info layout

### DIFF
--- a/client/src/components/machine.css
+++ b/client/src/components/machine.css
@@ -57,15 +57,19 @@
 /* Quiz Mode Info */
 .machine-quiz-info {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: space-around;
   align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 5;
   background-color: #eee;
   color: #000;
-  padding: 1rem;
+  padding: 0.5rem 1rem;
+  margin-bottom: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  margin-bottom: 1rem;
 }
 
 body.dark .machine-quiz-info {


### PR DESCRIPTION
## Summary
- keep `.machine-quiz-info` sticky while scrolling
- display quiz info elements in a row and space them out
- reduce margins and padding to make the info block compact

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869ac15439083258896adeb1134afd1